### PR TITLE
Add session start hook to install frontend dependencies

### DIFF
--- a/.claude/hooks/setup-frontend.sh
+++ b/.claude/hooks/setup-frontend.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+cd apps/server/src/main/webui
+pnpm install
+npx playwright install chrome

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/setup-frontend.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a Claude Code `SessionStart` hook that automatically runs `pnpm install` and `npx playwright install chrome` in `apps/server/src/main/webui/`
- Prevents wasted tokens on missing dependency errors when starting new Claude Code sessions or worktrees
- Both commands are idempotent, so the hook is safe to run on every session start

Closes #5

## Test plan
- [x] Start a new Claude Code session and verify the hook runs both commands
- [x] Verify `pnpm install` completes successfully
- [x] Verify `npx playwright install chrome` completes successfully
- [x] Confirm the hook is a no-op when dependencies are already installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)