### PR TITLE
Update opensearch-operator settings

### DIFF
--- a/deploy/apps/opensearch-operator.yaml
+++ b/deploy/apps/opensearch-operator.yaml
@@ -10,7 +10,7 @@ spec:
   source:
     repoURL: https://opensearch-project.github.io/opensearch-k8s-operator
     chart: opensearch-operator
-    targetRevision: 2.8.0
+    targetRevision: 2.8.3
     helm:
       releaseName: opensearch-operator
   destination:

--- a/deploy/envs/base/server/opensearch.yaml
+++ b/deploy/envs/base/server/opensearch.yaml
@@ -1,4 +1,4 @@
-apiVersion: opensearch.opster.io/v1
+apiVersion: opensearch.org/v1
 kind: OpenSearchCluster
 metadata:
   name: promptyard-opensearch
@@ -9,16 +9,13 @@ spec:
     httpPort: 9200
     vendor: opensearch
   security:
-    disable: true
     config:
-      adminCredentialsSecret:
-        name: promptyard-opensearch-admin-credentials
-  tls:
-    http:
-      generate: true
-    transport:
-      generate: true
-      perNode: true
+    tls:
+      http:
+        generate: true
+      transport:
+        generate: true
+        perNode: true
   nodePools:
     - component: nodes
       replicas: 3


### PR DESCRIPTION
- Upgrades the operator 2.8.3 so we have the right helm chart.
- Fixes the opensearch cluster on staging to have the right settings.