### PR TITLE
feat: implement skill upload feature (FEAT-016)

### DIFF
--- a/apps/server/src/main/webui/src/views/UploadSkillView.vue
+++ b/apps/server/src/main/webui/src/views/UploadSkillView.vue
@@ -141,7 +141,7 @@ defineExpose({ form, onSubmit, submitting })
         </FormItem>
       </FormField>
 
-      <FormField v-slot="{ value, handleChange }" name="zipFile">
+      <FormField v-slot="{ handleChange }" name="zipFile">
         <FormItem>
           <FormLabel>Zip File</FormLabel>
           <FormControl>


### PR DESCRIPTION
## Summary
This PR implements the skill upload feature allowing users to share reusable skills as zip files containing SKILL.md.

## Changes

### Backend (Kotlin/Quarkus)
- **Skill.kt**: Entity extending ContentItem with discriminator "skill", adds fileCount, fileSize, fileMetadata (JSONB), and previewContent
- **SkillRepository.kt**: Repository for Skill entity with findBySlug method
- **SkillService.kt**: Service for zip validation (max 10MB, SKILL.md required), parsing, and slug generation
- **SkillsResource.kt**: REST endpoint at /api/content/skills with POST (upload) and GET (detail) endpoints
- **DTOs**: SubmitSkillRequest, SubmitSkillResponse, SkillFileResponse, SkillDetailResponse
- **V5__AddSkillColumns.sql**: Flyway migration for skill-specific columns
- Updated ContentItemResponse, ContentItemsResource, and SearchResource to include fileCount and fileSize fields

### Frontend (Vue 3)
- **UploadSkillView.vue**: Upload form at /content/skills/new with validation
- **SkillDetailView.vue**: Detail page at /content/skills/:slug showing file list, preview, and download
- **skills.ts**: API service layer
- Router updated with new skill routes

## Testing
- Backend compiles successfully
- Frontend builds successfully

## Open Questions
- Should skills be publicly viewable or only visible to authors? (Currently implemented as public)
- What storage backend for zip files? (Currently stored as BLOB in database)
- File type whitelist inside zip? (Currently any file allowed, text files previewed)